### PR TITLE
Update run-rt-forecast.R

### DIFF
--- a/rt-forecast-2/forecast/utils/run-rt-forecast.R
+++ b/rt-forecast-2/forecast/utils/run-rt-forecast.R
@@ -49,6 +49,7 @@ run_rt_forecast <- function(deaths, submission_date, rerun = FALSE) {
                                         samples = 2000,
                                         warmup = 500,
                                         burn_in = 14,
+                                        non_zero_points = 14,
                                         adapt_delta = 0.98,
                                         cores = no_cores,
                                         chains = ifelse(no_cores <= 2, 2, no_cores),


### PR DESCRIPTION
EpiNow2 needs some level of non-zero data in the time-series in order to produce sane results. This check will cause estimates to not be run in places without at least 14 days of non-zero in the last 12 weeks (or fewer if using a different rolling window to the global estimates). Not sure but this may require some additional downstream checks as I expect the formatting/ensembling code wants there to always be forecasts.