### PR TITLE
correct timeseries cumulative forecast formatting

### DIFF
--- a/rt-forecast-2/format/utils/format-forecast-us.R
+++ b/rt-forecast-2/format/utils/format-forecast-us.R
@@ -33,7 +33,7 @@ format_forecast_us <- function(forecasts, shrink_per = 0,
   
   # Add cumulative from last week
   cumulative_state <- data.table(get_us_deaths(data = "cumulative"))
-  cumulative_state <- cumulative_state[date == max(cumulative_state$date), 
+  cumulative_state <- cumulative_state[date == forecast_date, 
                                                .(state, deaths)]
   cumulative_national <- cumulative_state[, .(deaths = sum(deaths), 
                                               state = "US")]

--- a/rt-forecast-2/format/utils/format-rt.R
+++ b/rt-forecast-2/format/utils/format-rt.R
@@ -24,7 +24,7 @@ format_rt <- function(forecast_date, submission_date, include_latest = FALSE,
     # Set directory ------------------------------------------------------
     
     i <- gsub("rt2_", "", i)
-    message("Formating: ", i, " on the ", forecast_date)
+    message("Formatting: ", i, " on the ", forecast_date)
     
     forecast_dir <- here::here("rt-forecast-2/forecast/deaths_forecast", i)
     output_dir <- here::here("rt-forecast-2/output", i)
@@ -45,23 +45,15 @@ format_rt <- function(forecast_date, submission_date, include_latest = FALSE,
     
     # Load forecasts ----------------------------------------------------------
     
-    # Try yesterday's date for latest Rt forecast file
+    # Try forecast date date for latest Rt forecast file
     forecasts_raw <- suppressWarnings(
       EpiNow2::get_regional_results(results_dir = file.path(forecast_dir, "state"),
                                                    date = lubridate::ymd(forecast_date),
                                                    forecast = TRUE)$estimated_reported_cases$samples
     )
     
-    # If nothing returns, try today's date
-    if(length(forecasts_raw) == 0){
-      forecasts_raw <- suppressWarnings(
-        EpiNow2::get_regional_results(results_dir = file.path(forecast_dir, "state"),
-                                      date = lubridate::ymd(forecast_date),
-                                      forecast = TRUE)$estimated_reported_cases$samples
-      )
-      
       if(length(forecasts_raw) == 0){
-        warning("<format-rt.R> Latest Rt forecasts are not found. Check forecast_date and directory paths")
+        warning("<format-rt.R> Latest Rt forecasts are not found. Check forecast_date matches directory paths")
         }
     }
     

--- a/timeseries-forecast/deaths-on-cases/ts-deaths-on-cases-forecast.R
+++ b/timeseries-forecast/deaths-on-cases/ts-deaths-on-cases-forecast.R
@@ -56,7 +56,7 @@ ts_deaths_on_cases_forecast <- function(case_data, deaths_data, case_quantile,
 
 # Forecast cases ---------------------------------------------------------
     
-  case_forecast <- case_data_weekly %>%
+  case_forecast <- suppressMessages(case_data_weekly %>%
       group_by(state) %>%
       group_modify(~ EpiSoon::forecastHybrid_model(y = filter(.x, epiweek %in% historical_weeks) %>%
                                                      pull("cases"),
@@ -66,7 +66,7 @@ ts_deaths_on_cases_forecast <- function(case_data, deaths_data, case_quantile,
                                                                        a.args = list()),
                                                    forecast_params = list(PI.combination = "mean"))) %>%
       mutate(sample = rep(1:sample_count)) %>%
-      tidyr::pivot_longer(cols = starts_with("..."), names_to = "epiweek")
+      tidyr::pivot_longer(cols = starts_with("..."), names_to = "epiweek"))
     
     # Get quantile
       quantile <- case_forecast %>%
@@ -108,7 +108,7 @@ ts_deaths_on_cases_forecast <- function(case_data, deaths_data, case_quantile,
         full_join(deaths_data_weekly, by = c("state", "epiweek"))
       
       # Forecast deaths (y) using cases
-      death_forecast <- cases_deaths %>%
+      death_forecast <- suppressMessages(cases_deaths %>%
         group_by(state) %>%
         group_modify(~ EpiSoon::forecastHybrid_model(y = filter(.x, epiweek %in% historical_weeks) %>%
                                                        pull("deaths"),
@@ -136,7 +136,7 @@ ts_deaths_on_cases_forecast <- function(case_data, deaths_data, case_quantile,
                                                                             PI.combination = "mean")
                                                      )) %>%
         mutate(sample = rep(1:sample_count)) %>%
-        tidyr::pivot_longer(cols = starts_with("..."), names_to = "epiweek")
+        tidyr::pivot_longer(cols = starts_with("..."), names_to = "epiweek"))
       
       
 

--- a/timeseries-forecast/deaths-only/ts-deaths-only-forecast.R
+++ b/timeseries-forecast/deaths-only/ts-deaths-only-forecast.R
@@ -45,7 +45,7 @@ ts_deaths_only_forecast <- function(data,
   
   
   # Forecast 
-  death_forecast <- data_weekly %>%
+  death_forecast <- suppressMessages(data_weekly %>%
     group_by(state) %>%
     group_modify(~ EpiSoon::forecastHybrid_model(y = filter(.x, epiweek %in% historical_weeks) %>%
                                                    pull("deaths"),
@@ -54,7 +54,7 @@ ts_deaths_only_forecast <- function(data,
                                                  model_params = list(models = "aez", weights = "equal"),
                                                  forecast_params = list(PI.combination = "mean"))) %>%
     mutate(sample = rep(1:sample_count)) %>%
-    tidyr::pivot_longer(cols = starts_with("..."), names_to = "epiweek")
+    tidyr::pivot_longer(cols = starts_with("..."), names_to = "epiweek"))
   
   # Format
   dates_from <- unique(death_forecast$epiweek)

--- a/utils/check-incident-to-cumulative.R
+++ b/utils/check-incident-to-cumulative.R
@@ -1,0 +1,47 @@
+# Check incident forecast adds to cumulative
+source("utils/load-submissions-function.R")
+source("utils/get-us-data.R")
+state_codes <- readRDS("utils/state_codes.rds")
+
+# get cumulative data
+cumulative <- get_us_deaths(data = "cumulative") %>%
+  dplyr::ungroup() %>%
+  dplyr::filter(date == forecast_date) %>%
+  dplyr::add_row(state="US", deaths = sum(.$deaths), date = forecast_date) %>%
+  dplyr::left_join(state_codes, by = "state")
+
+# Check each model to find the issue
+
+forecasts <- load_submission_files(dates = "all", num_last = 1, models = "single") %>%
+  dplyr::filter(location == "US")
+
+us_inc <- dplyr::filter(forecasts, grepl("inc", forecasts$target))
+
+us_cum <- dplyr::filter(forecasts, grepl("cum", forecasts$target)) %>%
+  dplyr::group_by(location, quantile, type) %>%
+  dplyr::mutate(cum_to_inc = value - dplyr::lag(value, 1)) %>%
+  dplyr::ungroup()
+
+
+us_join <- dplyr::left_join(us_inc, us_cum, by = c("model", 
+                                                   "location", "target_end_date", 
+                                                   "type", "quantile")) %>%
+  dplyr::left_join(cumulative, by = c("location")) %>%
+  dplyr::rename(value_inc = value.x, value_cum = value.y) %>%
+  dplyr::mutate(cum_to_inc = ifelse(is.na(cum_to_inc), value_cum - deaths, cum_to_inc),
+                diff_inc_cum = value_inc - cum_to_inc) %>%
+  dplyr::select(model,
+                location, state, target_end_date, type, quantile, deaths, 
+                value_inc, value_cum, cum_to_inc, diff_inc_cum)
+
+us_summary <- dplyr::group_by(us_join, model) %>%
+  dplyr::summarise(diff_mean = mean(diff_inc_cum),
+                   .groups = "drop")
+
+if(!mean(us_join$diff_inc_cum) == 0){
+  warning("Incident and cumulative forecasts don't match")
+}
+
+
+
+


### PR DESCRIPTION
- Fixed a bug (by re-write from scratch) to make sure that the cumulative timeseries forecast is based off the same incident forecast that get submitted. Some bug meant these did not add up.
- Added an incident-to-cumulative check when running the final submissions file.