### PR TITLE
Update forecast.sh

### DIFF
--- a/bin/forecast.sh
+++ b/bin/forecast.sh
@@ -12,5 +12,8 @@ bash bin/update-for-target-date.sh
 # Finalise submission
 Rscript submissions/finalise.R
 
+# Render report
+Rscript -e "rmarkdown::render('submissions/report.Rmd')"
+
 # Submit
 # See: https://github.com/reichlab/covid19-forecast-hub/blob/master/data-processed/README.md


### PR DESCRIPTION
This is a YOLO in the Github interface but should mean the report gets rendered in the scheduled fitting job. I've also turned on GitHub Pages so in theory the report should show up at: https://epiforecasts.io/covid-us-forecasts/submissions/report.html

This might streamline some of the submission processes as my understanding is that for checking only the data anomalies file needs to be updated ahead of time. 

I've not thought about a nice way to trigger a submission with a changed subset of models yet that doesn't involve running code. 